### PR TITLE
Enable build with linux_x86_64 system

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,5 +9,5 @@ board = uno
 monitor_speed = 115200
 lib_deps =
     Servo@1.1.6
-    LiquidCrystal@1.0.7
+    LiquidCrystal@1.5.0
     OneButton@c8651328e3

--- a/src/arduino/respi_v0.cpp
+++ b/src/arduino/respi_v0.cpp
@@ -1,3 +1,4 @@
+#include <Wire.h>
 #include <Arduino.h>
 #include <Servo.h>
 #include <LiquidCrystal.h>


### PR DESCRIPTION
When I tried to build the project under linux_x86_64 system, I had a trouble with
LiquidCrystal@1.0.7. There is not version of the library that satisfies the requirement 1.0.7.

After some digging, I tried with the latest version of LiquidCrystal found here:
https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home

* LiquidCrystal@1.5.0

I also add `#include <Wire.h>` as it seems to be mandatory.
Now the build succeed. I don't know how to properly test the software.
Don't hesitate to integrate or fire this modification.