### PR TITLE
software: get rid of float variables

### DIFF
--- a/src/software/firmware/includes/pression.h
+++ b/src/software/firmware/includes/pression.h
@@ -18,4 +18,4 @@
  * used when in simulation mode)
  * @return         The current pressure in mmH20
  */
-int readPressureSensor(uint16_t centiSec);
+int16_t readPressureSensor(uint16_t centiSec);

--- a/src/software/firmware/srcs/pressure_controller.cpp
+++ b/src/software/firmware/srcs/pressure_controller.cpp
@@ -400,7 +400,7 @@ int32_t PressureController::pidBlower(int32_t targetPressure, int32_t currentPre
     // Compute derivative
     int32_t derivative = (blowerLastError == INVALID_ERROR_MARKER || dt == 0)
                              ? 0
-                             : derivative = 1000000.0 * (error - blowerLastError) / dt;
+                             : derivative = 1000000 * (error - blowerLastError) / dt;
     blowerLastError = error;
 
     int32_t blowerCommand = PID_BLOWER_KP * error + blowerIntegral
@@ -422,13 +422,13 @@ PressureController::pidPatient(int32_t targetPressure, int32_t currentPressure, 
     int32_t error = targetPressure - currentPressure;
 
     // Compute integral
-    patientIntegral = patientIntegral + PID_PATIENT_KI * error * dt / 1000000.0;
+    patientIntegral = patientIntegral + PID_PATIENT_KI * error * dt / 1000000;
     patientIntegral = max(PID_PATIENT_INTEGRAL_MIN, min(PID_PATIENT_INTEGRAL_MAX, patientIntegral));
 
     // Compute derivative
     int32_t derivative = (patientLastError == INVALID_ERROR_MARKER || dt == 0)
                              ? 0
-                             : derivative = 1000000.0 * (error - patientLastError) / dt;
+                             : derivative = 1000000 * (error - patientLastError) / dt;
     patientLastError = error;
 
     int32_t patientCommand = PID_PATIENT_KP * error + patientIntegral


### PR DESCRIPTION
it has been recommended to use only integer values.