### PR TITLE
software: activation - fix stop button behavior

### DIFF
--- a/src/software/firmware/includes/activation.h
+++ b/src/software/firmware/includes/activation.h
@@ -20,6 +20,13 @@ class ActivationController {
     ActivationController();
 
     /**
+     * Refresh the current state
+     *
+     * @warning It must be called regularly to protect against time counter overflow
+     */
+    void refreshState();
+
+    /**
      * Return if breathing is activated or not
      */
     bool isRunning() const { return m_state != STOPPED; }

--- a/src/software/firmware/srcs/activation.cpp
+++ b/src/software/firmware/srcs/activation.cpp
@@ -47,3 +47,13 @@ void ActivationController::onStopButton() {
         break;
     }
 }
+
+void ActivationController::refreshState() {
+    // If the 2nd STOP deadline is exceeded, switch back
+    // to running state. This is needed to make sure millis() counter
+    // overflow does not make the test invalid
+    if ((m_state == RUNNING_READY_TO_STOP)
+        && ((millis() - m_timeOfLastStopPushed) >= SECOND_STOP_MAX_DELAY_MS)) {
+        m_state = RUNNING;
+    }
+}

--- a/src/software/firmware/srcs/respirator.cpp
+++ b/src/software/firmware/srcs/respirator.cpp
@@ -178,6 +178,7 @@ void loop(void) {
     /********************************************/
     // INITIALIZE THE RESPIRATORY CYCLE
     /********************************************/
+    activationController.refreshState();
     bool shouldRun = activationController.isRunning();
     pController.initRespiratoryCycle();
 


### PR DESCRIPTION
There is a small risk that the millis() counter makes a round trip and test `(millis() - m_timeOfLastStopPushed) < SECOND_STOP_MAX_DELAY_MS` becomes true again unexpectedly