### PR TITLE
software: wait end of cycle before showing stop

### DIFF
--- a/src/software/firmware/srcs/respirator.cpp
+++ b/src/software/firmware/srcs/respirator.cpp
@@ -219,7 +219,7 @@ void loop(void) {
                 displayCurrentSettings(pController.maxPeakPressureCommand(),
                                        pController.maxPlateauPressureCommand(),
                                        pController.minPeepCommand());
-                if (activationController.isRunning()) {
+                if (shouldRun) {
                     displayCurrentInformation(pController.peakPressure(),
                                               pController.plateauPressure(), pController.peep());
                 } else {


### PR DESCRIPTION
Wait for the cycle to be finished before displaying stopped state info

Disclaimer: I dont know if there was an issue here, but just in case the PR is ready :) 

