### PR TITLE
fix blower slow down problems

### DIFF
--- a/src/software/firmware/includes/blower.h
+++ b/src/software/firmware/includes/blower.h
@@ -15,7 +15,7 @@
 
 // Convert a speed to a value in microseconds for the blower controller
 // There is an error margin on the max ppm, because the blower do not handle values greater
-// than 2.01 ms, and there is no quartz anywhere.
+// than 2.01 ms, and there is no quartz anywhere
 #define BlowerSpeed2MicroSeconds(value) map(value, 0, 180, 1000, 1950)
 
 // CLASS =================================================================

--- a/src/software/firmware/includes/blower.h
+++ b/src/software/firmware/includes/blower.h
@@ -14,7 +14,9 @@
 #include "../includes/parameters.h"
 
 // Convert a speed to a value in microseconds for the blower controller
-#define BlowerSpeed2MicroSeconds(value) map(value, 0, 180, 1000, 2000)
+// There is an error margin on the max ppm, because the blower do not handle values greater
+// than 2.01 ms, and there is no quartz anywhere.
+#define BlowerSpeed2MicroSeconds(value) map(value, 0, 180, 1000, 1950)
 
 // CLASS =================================================================
 

--- a/src/software/firmware/includes/blower.h
+++ b/src/software/firmware/includes/blower.h
@@ -53,4 +53,5 @@ class Blower {
     uint16_t timerChannel;
     uint16_t blowerPin;
     int16_t m_speed;
+    bool m_stopped;
 };

--- a/src/software/firmware/includes/parameters.h
+++ b/src/software/firmware/includes/parameters.h
@@ -121,7 +121,7 @@ static const int32_t PID_PATIENT_SAFETY_PEEP_OFFSET = 10;
 #define TIM_CHANNEL_SERVO_VALVE_PATIENT 2
 #define ESC_PPM_PERIOD                                                                             \
     10000  // ESC should be driven in 50 Hz. 100 Hz is a security against ESC or nucleo bugs. Some
-           // ESC stops very quickly.
+           // ESC stops very quickly
 #endif
 
 ///@}

--- a/src/software/firmware/includes/parameters.h
+++ b/src/software/firmware/includes/parameters.h
@@ -103,7 +103,7 @@ static const int32_t PID_PATIENT_SAFETY_PEEP_OFFSET = 10;
 #if VALVE_TYPE == VT_SERVO_V1
 #define SERVO_VALVE_PERIOD                                                                         \
     10000  // 100 Hz : on hardware 1, esc timer is shared between servo and esc. Servo can handle
-           // 100hz too.
+           // 100hz too
 #elif VALVE_TYPE == VT_EMERSON_ASCO
 #define SERVO_VALVE_PERIOD 3278  // 305 Hz
 #define EMERSON_MIN_PWM 600      // 18 % PWM is the minimum to start opening (3278 * 0.18)

--- a/src/software/firmware/includes/parameters.h
+++ b/src/software/firmware/includes/parameters.h
@@ -101,7 +101,9 @@ static const int32_t PID_PATIENT_SAFETY_PEEP_OFFSET = 10;
 /// Angle when closed
 #define VALVE_CLOSED_STATE 125u
 #if VALVE_TYPE == VT_SERVO_V1
-#define SERVO_VALVE_PERIOD 20000  // 50 Hz
+#define SERVO_VALVE_PERIOD                                                                         \
+    10000  // 100 Hz : on hardware 1, esc timer is shared between servo and esc. Servo can handle
+           // 100hz too.
 #elif VALVE_TYPE == VT_EMERSON_ASCO
 #define SERVO_VALVE_PERIOD 3278  // 305 Hz
 #define EMERSON_MIN_PWM 600      // 18 % PWM is the minimum to start opening (3278 * 0.18)
@@ -118,8 +120,8 @@ static const int32_t PID_PATIENT_SAFETY_PEEP_OFFSET = 10;
 #define TIM_CHANNEL_SERVO_VALVE_BLOWER 1
 #define TIM_CHANNEL_SERVO_VALVE_PATIENT 2
 #define ESC_PPM_PERIOD                                                                             \
-    10000  // ESC is driven in 50 Hz. 100 Hz is a security against ESC or nucleo bugs. Some ESC
-           // stops very quickly.
+    10000  // ESC should be driven in 50 Hz. 100 Hz is a security against ESC or nucleo bugs. Some
+           // ESC stops very quickly.
 #endif
 
 ///@}

--- a/src/software/firmware/includes/parameters.h
+++ b/src/software/firmware/includes/parameters.h
@@ -118,8 +118,8 @@ static const int32_t PID_PATIENT_SAFETY_PEEP_OFFSET = 10;
 #define TIM_CHANNEL_SERVO_VALVE_BLOWER 1
 #define TIM_CHANNEL_SERVO_VALVE_PATIENT 2
 #define ESC_PPM_PERIOD                                                                             \
-    15000  // ESC is driven in 50 Hz. 66 Hz is a security against ESC or nucleo bugs. Some ESC stops
-           // very quickly.
+    10000  // ESC is driven in 50 Hz. 100 Hz is a security against ESC or nucleo bugs. Some ESC
+           // stops very quickly.
 #endif
 
 ///@}

--- a/src/software/firmware/srcs/blower.cpp
+++ b/src/software/firmware/srcs/blower.cpp
@@ -37,7 +37,7 @@ void Blower::setup() {
 
 void Blower::runSpeed(int16_t p_speed) {
     if ((p_speed > MIN_BLOWER_SPEED) && (p_speed < MAX_BLOWER_SPEED)) {
-        // do not forcefully set the capture compare again and again if speed do not change.
+        // do not forcefully set the capture compare again and again if speed do not change
         if (m_speed != p_speed) {
             actuator->setCaptureCompare(timerChannel, BlowerSpeed2MicroSeconds(p_speed),
                                         MICROSEC_COMPARE_FORMAT);

--- a/src/software/firmware/srcs/blower.cpp
+++ b/src/software/firmware/srcs/blower.cpp
@@ -23,7 +23,7 @@ Blower::Blower(HardwareTimer* p_hardwareTimer, uint16_t p_timerChannel, uint16_t
     actuator = p_hardwareTimer;
     timerChannel = p_timerChannel;
     blowerPin = p_blowerPin;
-
+    m_stopped = true;
     m_speed = DEFAULT_BLOWER_SPEED;
 }
 
@@ -38,10 +38,11 @@ void Blower::setup() {
 void Blower::runSpeed(int16_t p_speed) {
     if ((p_speed > MIN_BLOWER_SPEED) && (p_speed < MAX_BLOWER_SPEED)) {
         // do not forcefully set the capture compare again and again if speed do not change
-        if (m_speed != p_speed) {
+        if (m_stopped || m_speed != p_speed) {
             actuator->setCaptureCompare(timerChannel, BlowerSpeed2MicroSeconds(p_speed),
                                         MICROSEC_COMPARE_FORMAT);
             m_speed = p_speed;
+            m_stopped = false;
         }
     } else {
         DBG_DO(Serial.print("Blower value is wrong: "));
@@ -53,4 +54,5 @@ int Blower::getSpeed() const { return m_speed; }
 
 void Blower::stop() {
     actuator->setCaptureCompare(timerChannel, BlowerSpeed2MicroSeconds(0), MICROSEC_COMPARE_FORMAT);
+    m_stopped = true;
 }

--- a/src/software/firmware/srcs/blower.cpp
+++ b/src/software/firmware/srcs/blower.cpp
@@ -37,9 +37,12 @@ void Blower::setup() {
 
 void Blower::runSpeed(int16_t p_speed) {
     if ((p_speed > MIN_BLOWER_SPEED) && (p_speed < MAX_BLOWER_SPEED)) {
-        actuator->setCaptureCompare(timerChannel, BlowerSpeed2MicroSeconds(p_speed),
-                                    MICROSEC_COMPARE_FORMAT);
-        m_speed = p_speed;
+        // do not forcefully set the capture compare again and again if speed do not change.
+        if (m_speed != p_speed) {
+            actuator->setCaptureCompare(timerChannel, BlowerSpeed2MicroSeconds(p_speed),
+                                        MICROSEC_COMPARE_FORMAT);
+            m_speed = p_speed;
+        }
     } else {
         DBG_DO(Serial.print("Blower value is wrong: "));
         DBG_DO(Serial.println(p_speed));

--- a/src/software/firmware/srcs/integration_test.cpp
+++ b/src/software/firmware/srcs/integration_test.cpp
@@ -167,6 +167,7 @@ void loop() {
             servoBlower.execute();
             servoPatient.open();
             servoPatient.execute();
+            blower.stop();
         });
         break;
     }
@@ -176,7 +177,10 @@ void loop() {
         break;
     }
     case STEP_VALVE_BLOWER_TEST: {
-        UNGREEDY(is_drawn, display("Test Valve inspi", "Continuer : Start"));
+        UNGREEDY(is_drawn, {
+            display("Test Valve inspi", "Continuer : Start");
+            blower.stop();
+        });
 
         if (millis() - last_time < 5000) {
             servoBlower.open();
@@ -245,7 +249,10 @@ void loop() {
     }
 
     case STEP_BATTERY_TEST: {
-        UNGREEDY(is_drawn, display("Test batterie", "Continuer : Start"));
+        UNGREEDY(is_drawn, {
+            display("Test batterie", "Continuer : Start");
+            blower.stop();
+        });
         updateBatterySample();
         if (millis() - last_time >= 200) {
             char msg[SCREEN_LINE_LENGTH + 1];

--- a/src/software/firmware/srcs/integration_test.cpp
+++ b/src/software/firmware/srcs/integration_test.cpp
@@ -149,6 +149,7 @@ void setup() {
     BuzzerControl_Init();
     Buzzer_Init();
     initBattery();
+    blower.stop();
 
     pinMode(PIN_LED_START, OUTPUT);
     digitalWrite(PIN_LED_START, LED_START_ACTIVE);
@@ -156,7 +157,6 @@ void setup() {
 
 void loop() {
     btn_start.tick();
-    blower.stop();
 
     switch (step) {
     case STEP_WELCOME: {


### PR DESCRIPTION
This should fix the blower slowing down problems.
- integration test state machine was calling blower.stop() in the loop -> sync problem that ultimately lead to send 1ms ppm sometimes...
- increased the ppm frequency again to 100Hz as a work around to ESC internal firmware problems. Also fixed this on hardware 1.
